### PR TITLE
Don't try to change item meta when there is none

### DIFF
--- a/Core/src/main/java/com/songoda/core/world/SItemStack.java
+++ b/Core/src/main/java/com/songoda/core/world/SItemStack.java
@@ -35,7 +35,10 @@ public class SItemStack {
     public ItemStack addDamage(Player player, int damage) {
         if (item == null)
             return null;
-
+        
+        if(item.getItemMeta() == null)
+            return item;
+        
         int maxDurability = item.getType().getMaxDurability();
         int durability;
 


### PR DESCRIPTION
Fixes an error in UltimateTimber that is caused when you try to punch a tree with your fist.