### PR TITLE
Added asyncFuture

### DIFF
--- a/Core/src/main/java/com/songoda/core/database/DataManagerAbstract.java
+++ b/Core/src/main/java/com/songoda/core/database/DataManagerAbstract.java
@@ -12,6 +12,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
 
 public class DataManagerAbstract {
 
@@ -67,6 +68,16 @@ public class DataManagerAbstract {
      */
     public void async(Runnable runnable) {
         Bukkit.getScheduler().runTaskAsynchronously(this.plugin, runnable);
+    }
+    
+    /**
+     * Queue a task to be run asynchronously with all the
+     * advantages of CompletableFuture api <br>
+     *
+     * @param runnable task to run
+     */
+    public CompletableFuture<Void> asyncFuture(Runnable runnable) {
+       return CompletableFuture.runAsync(runnable);
     }
 
     /**


### PR DESCRIPTION
Added a method to run a task async but return a CompletableFuture. Useful if you want the task to be asynchronous but also wait for it to finish and concatenate another task or more functionalities with the CompletableFuture API